### PR TITLE
Include government banner

### DIFF
--- a/app/components/GovernmentBanner.tsx
+++ b/app/components/GovernmentBanner.tsx
@@ -1,0 +1,6 @@
+'use client'
+import { GovBanner } from "@trussworks/react-uswds";
+
+export default function GovernmentBanner() {
+    return <GovBanner />
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import StoreProvider  from './StoreProvider'
 import "./globals.css";
+import GovernmentBanner from "./components/GovernmentBanner";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
@@ -16,7 +17,7 @@ function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}><StoreProvider>{children}</StoreProvider></body>
+      <body className={inter.className}><StoreProvider><GovernmentBanner />{children}</StoreProvider></body>
     </html>
   );
 }


### PR DESCRIPTION
The government banner [component](https://trussworks.github.io/react-uswds/?path=/docs/components-banner--docs) from React USWDS is a nextjs client component because it handles the onClick event. This PR wraps the component in a component that has `'use client'` at the top to make it a client component.

Screenshots:
![Screen Shot 2024-06-09 at 16 25 35-fullpage](https://github.com/JosephGasiorekUSDS/verify-nextjs/assets/169079684/4fcb38d0-a8b5-4398-a6da-63bc8e3686a5)
![Screen Shot 2024-06-09 at 16 25 37-fullpage](https://github.com/JosephGasiorekUSDS/verify-nextjs/assets/169079684/cd01c08d-187f-44ae-80c9-a7e30a1b4c0b)
