### PR TITLE
Add slack notification of deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - run: ./cf push
       - name: Post Slack Message
         run: |
-          curl --header "Content-Type: applicaiton/json" \
+          curl --header "Content-Type: application/json" \
             --request POST \ 
             --data '{"user": "${{github.actor}}", "prototype_url": "https://verify-prototype.fr.cloud.gov/ledger/income/add", "commit_url": "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"}' \ 
             https://hooks.slack.com/triggers/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


### PR DESCRIPTION
This sends the following message to a `Slack channel: {{user}} has deployed the verify prototype to {{prototype_url}}. Deploy commit: {{commit_url}}`. I was thinking it should go to `cx-ffs-verifications-team` but I am open to suggestions.