### PR TITLE
Only post if the change has been large

### DIFF
--- a/scripts/compare_coverage.js
+++ b/scripts/compare_coverage.js
@@ -63,6 +63,11 @@ module.exports = ({github, context, mainWorkflowRunSha, coverageFilePath, prNumb
             const prTotalCoverage = computeTotalCoverage(prCoverageData)
             const mainTotalCoverage = computeTotalCoverage(mainCoverageData)
 
+            if (Math.abs(prTotalCoverage-mainTotalCoverage) < 2) {
+                console.log("Only a small coverage change")
+                return
+            }
+
             let message = "This pull request "
             if (prTotalCoverage > mainTotalCoverage) {
                 // Coverage increased


### PR DESCRIPTION
It is annoying for the coverage bot to comment on PRs when there hasn't been much change.