### PR TITLE
FFS-1645 New placeholder screen for Grounding & Context

### DIFF
--- a/app/[locale]/introduction/page.test.tsx
+++ b/app/[locale]/introduction/page.test.tsx
@@ -7,7 +7,7 @@ import { vi } from 'vitest'
 import { EnhancedStore } from '@reduxjs/toolkit'
 import mockRouter from 'next-router-mock'
 
-describe('Intro Page', async () => {
+describe('Grounding and context page', async () => {
   let store: EnhancedStore
   beforeEach(() => {
     vi.mock('next/navigation', () => ({
@@ -21,18 +21,18 @@ describe('Intro Page', async () => {
   afterEach(cleanup)
 
   it('shows header', () => {
-    expect(screen.getByTestId('intro_header')).toBeDefined()
+    expect(screen.getByTestId('placeholder_header')).toBeDefined()
   })
 
-  it('shows add button', () => {
-    expect(screen.getByTestId('get_started_button')).toBeDefined()
+  it('shows button', () => {
+    expect(screen.getByTestId('placeholder_button')).toBeDefined()
   })
 
   it('navigates when clicked', async () => {
-    fireEvent.click(screen.getByTestId('get_started_button'))
+    fireEvent.click(screen.getByTestId('placeholder_button'))
     await waitFor(() => {
       expect(mockRouter).toMatchObject({
-        asPath: "/introduction"
+        asPath: "/introduction/how-this-works"
       })
     })
   })

--- a/app/[locale]/introduction/page.tsx
+++ b/app/[locale]/introduction/page.tsx
@@ -24,11 +24,11 @@ export default function Page() {
                 <GridContainer>
                 <Grid row gap>
                     <main className="usa-layout-docs">
-                        <h3>{t('placeholder_text')}</h3>
+                        <h3 data-testid="placeholder_header">{t('placeholder_text')}</h3>
                         <span className="usa-hint">{t('placeholder_text')}</span>
                         <p className="text-center">
                             <Button type="button" 
-                                onClick={mainButtonClicked} data-testid="get_started_button" className="margin-bottom-3 margin-top-3">{t('placeholder_button')}</Button>
+                                onClick={mainButtonClicked} data-testid="placeholder_button" className="margin-bottom-3 margin-top-3">{t('placeholder_button')}</Button>
                         </p>
                     </main>
                 </Grid>
@@ -36,5 +36,4 @@ export default function Page() {
             </div>
         </div>
     )
-
 }

--- a/app/[locale]/introduction/page.tsx
+++ b/app/[locale]/introduction/page.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useTranslation } from "react-i18next"
+import { useRouter } from "next/navigation"
+import { 
+    Button, 
+    Grid, 
+    GridContainer 
+  } from "@trussworks/react-uswds";
+import VerifyNav from "@/app/components/VerifyNav";
+
+export default function Page() {
+    const { t } = useTranslation()
+    const router = useRouter()
+
+    function mainButtonClicked() {
+        router.push('/introduction/how-this-works/');
+    }
+
+    return (
+        <div>
+            <VerifyNav title={t('intro_title')} />
+            <div className="usa-section">
+                <GridContainer>
+                <Grid row gap>
+                    <main className="usa-layout-docs">
+                        <h3>{t('placeholder_text')}</h3>
+                        <span className="usa-hint">{t('placeholder_text')}</span>
+                        <p className="text-center">
+                            <Button type="button" 
+                                onClick={mainButtonClicked} data-testid="get_started_button" className="margin-bottom-3 margin-top-3">{t('placeholder_button')}</Button>
+                        </p>
+                    </main>
+                </Grid>
+                </GridContainer>
+            </div>
+        </div>
+    )
+
+}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -10,7 +10,7 @@ export default function Home() {
   const router = useRouter()
 
   function getStartedClicked() {
-    router.push('/introduction/how-this-works/')
+    router.push('/introduction/')
   }
 
   const items = [

--- a/app/i18n/locales/en/translation.json
+++ b/app/i18n/locales/en/translation.json
@@ -151,6 +151,7 @@
   "nav_english": "English",
   "nav_espanol": "Español",
   "nav_home": "Home",
+  "placeholder_button": "Lorem ipsum Next",
   "placeholder_text": "Lorem ipsum",
   "required_field_description": "A red asterisk (<0></0>) indicates a required field.",
   "review_continue_button": "Continue",


### PR DESCRIPTION
## Ticket
[FFS-1645](https://jiraent.cms.gov/browse/FFS-1645)

## Overview
This work inserts a page in between the first page (DL home) and the second page (DL how-it-works). This new page is a placeholder that is awaiting design work and, as a result, contains no content other than navigating to the subsequent how-it-works page.

Url: `<domain>/introduction`

## Demonstration
https://github.com/user-attachments/assets/a0b06373-0c7b-4608-87ea-41fccbfae721

## Test run
<img width="965" alt="Screenshot 2024-10-09 at 10 03 59 PM" src="https://github.com/user-attachments/assets/c8885601-3035-4d28-a321-17e8d55bf501">


